### PR TITLE
[1-team] june's Promise implementation

### DIFF
--- a/src/june/promise.js
+++ b/src/june/promise.js
@@ -1,0 +1,57 @@
+class Promise {
+  constructor(callback) {
+    this.state = 'pending';
+    this.onFulfilledCallback = null;
+    this.onRejectedCallback = null;
+    const resolve = value => {
+      this.state = 'fulfilled';
+      this.value = value;
+      if (this.onFulfilledCallback !== null) {
+        this.onFulfilledCallback(value);
+      }
+    };
+    const reject = value => {
+      this.state = 'rejected';
+      this.value = value;
+      if (this.onRejectedCallback !== null) {
+        this.onRejectedCallback(value);
+      }
+    };
+    callback(resolve, reject);
+  }
+
+  then(callback) {
+    if (this.state === 'pending') {
+      this.onFulfilledCallback = callback;
+    }
+    if (this.state === 'fulfilled') {
+      callback(this.value);
+    }
+    return this;
+  }
+
+  catch(callback) {
+    if (this.state === 'pending') {
+      this.onRejectedCallback = callback;
+    }
+    if (this.state === 'rejected') {
+      callback(this.value);
+    }
+    return this;
+  }
+  getValue() {
+    return this.value;
+  }
+}
+
+function asyncResolve() {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => resolve('resolved after 1s'), 1000);
+  });
+}
+
+asyncResolve().then(result => console.log(result));
+
+asyncResolve()
+  .then(result => `next ${result}`)
+  .then(result => console.log(`should log "next result" but ${result} logged`));


### PR DESCRIPTION
비동기를 지원하는 Promise 구현까지는 [자바스크립트의 Promise 직접 구현하기](https://blog.hyunmin.dev/14)를 보고 카피했습니다.

앞으로
- [ ] 체이닝 지원
- [ ] 비동기 체이닝 지원
두 가지를 직접 구현해 보려고 합니다